### PR TITLE
[UPDATE] search serialization method for Hostel Notices

### DIFF
--- a/backend/search/search_indexes.py
+++ b/backend/search/search_indexes.py
@@ -1,6 +1,6 @@
 import datetime
 from haystack import indexes
-from academics.models import Notice
+from academics.models import Notice, HostelNotice
 from department.models import Faculty
 
 
@@ -11,6 +11,19 @@ class NoticeIndex(indexes.SearchIndex, indexes.Indexable):
 
     def get_model(self):
         return Notice
+
+    def index_queryset(self, using=None):
+        """Used when the entire index for model is updated."""
+        return self.get_model().objects.filter(date__lte=datetime.datetime.now())
+
+
+class HostelNoticeIndex(indexes.SearchIndex, indexes.Indexable):
+    text = indexes.CharField(document=True, use_template=True)
+    notice_type = indexes.CharField(model_attr='hall_type')
+    date = indexes.DateTimeField(model_attr='date')
+
+    def get_model(self):
+        return HostelNotice
 
     def index_queryset(self, using=None):
         """Used when the entire index for model is updated."""

--- a/backend/search/serializers.py
+++ b/backend/search/serializers.py
@@ -1,12 +1,18 @@
 from rest_framework import serializers
-from academics.models import Notice
+from academics.models import Notice, HostelNotice
 from department.models import Faculty
 
 
-class NoticeSearchSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Notice
-        fields = ('title', 'notice_type', 'file', 'date')
+class GeneralNoticeSearchSerializer(serializers.Serializer):
+    title = serializers.CharField(max_length=1024)
+    notice_type = serializers.SerializerMethodField()
+    file = serializers.FileField(required=False)
+    date = serializers.DateField()
+
+    def get_notice_type(self, obj):
+        if isinstance(obj, HostelNotice):
+            return 'Hostel'
+        return getattr(obj, 'notice_type', None)
 
 
 class FacultySearchSerializer(serializers.ModelSerializer):

--- a/backend/search/serializers.py
+++ b/backend/search/serializers.py
@@ -3,7 +3,7 @@ from academics.models import Notice, HostelNotice
 from department.models import Faculty
 
 
-class GeneralNoticeSearchSerializer(serializers.Serializer):
+class NoticeSearchSerializer(serializers.Serializer):
     title = serializers.CharField(max_length=1024)
     notice_type = serializers.SerializerMethodField()
     file = serializers.FileField(required=False)

--- a/backend/search/views.py
+++ b/backend/search/views.py
@@ -5,14 +5,14 @@ from rest_framework.permissions import AllowAny
 from haystack.generic_views import SearchView
 from haystack.query import SearchQuerySet, EmptySearchQuerySet
 
-from search.serializers import GeneralNoticeSearchSerializer
+from search.serializers import NoticeSearchSerializer
 from search.serializers import FacultySearchSerializer
 from academics.models import Notice, HostelNotice
 from department.models import Faculty
 
 
 class NoticeSearchViewSet(ListAPIView):
-    serializer_class = GeneralNoticeSearchSerializer
+    serializer_class = NoticeSearchSerializer
     permission_classes = (AllowAny,)
 
     def get_queryset(self):

--- a/backend/search/views.py
+++ b/backend/search/views.py
@@ -5,14 +5,14 @@ from rest_framework.permissions import AllowAny
 from haystack.generic_views import SearchView
 from haystack.query import SearchQuerySet, EmptySearchQuerySet
 
-from search.serializers import NoticeSearchSerializer
+from search.serializers import GeneralNoticeSearchSerializer
 from search.serializers import FacultySearchSerializer
-from academics.models import Notice
+from academics.models import Notice, HostelNotice
 from department.models import Faculty
 
 
 class NoticeSearchViewSet(ListAPIView):
-    serializer_class = NoticeSearchSerializer
+    serializer_class = GeneralNoticeSearchSerializer
     permission_classes = (AllowAny,)
 
     def get_queryset(self):
@@ -21,7 +21,8 @@ class NoticeSearchViewSet(ListAPIView):
 
         if request.GET.get('q', ''):
             query = request.GET.get('q', '')
-            queryset = SearchQuerySet().models(Notice).filter(content=query).order_by('-date')
+            queryset = SearchQuerySet().models(Notice, HostelNotice).filter(
+                content=query).order_by('-date')
             return [i.object for i in queryset]
 
 


### PR DESCRIPTION
This PR changes the Serialization method for the search api, to support searching in two different models using same ViewSet.

Need to run `rebuild_index` command after merging this.